### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@ FlashlightPlugins
 
 4th-party plugins of Flashlight (https://github.com/nate-parrott/Flashlight/)
 
-##Install##
+## Install ##
 
 - Install and enable Flashlight (https://github.com/nate-parrott/Flashlight/releases)
 - Copy plugin bundle to `~/Library/FlashlightPlugins`
 
 If you are familiar with command lines, you can use `ln -s bundle_name.bundle ~/Library/FlashlightPlugins` for easier update via git.
 
-##Usage##
+## Usage ##
 
-###Timestamp###
+### Timestamp ###
 
 - `timestamp` for current timestamp
 - `timestamp 1400000000` to convert timestamp into human redable time string
 
 `ts` is short for `timestamp`, you can also use `ts 1400000000` for less typing.
 
-###Haomatong###
+### Haomatong ###
 
 - `haomatong 10086` to fetch info from haomatong for specified phone number
 
@@ -29,13 +29,13 @@ If you are familiar with command lines, you can use `ln -s bundle_name.bundle ~/
 
 ![Haomatong](images/haomatong.png)
 
-###Kuaidi###
+### Kuaidi ###
 
 - `kuaidi 100033892580` to fetch express info from kuaidi100.com
 
 ![Kuaidi](images/kuaidi.png)
 
-###YoudaoDic (by [Hyde Wang](https://github.com/callmewhy))###
+### YoudaoDic (by [Hyde Wang](https://github.com/callmewhy)) ###
 
 - `youdao one` to translate `one` from English to Chinese.
 - `youdao 汪` to translate `汪` from Chinese to English.
@@ -46,13 +46,13 @@ Press ENTER to see translation on dic.youdao.com in browser
 
 ![Youdao](images/youdao.png)
 
-###Douban###
+### Douban ###
 
 - `douban Interstellar` to search for a movie on douban
 
 ![Douban](images/douban.png)
 
-###ZhiHuDaily (By [小贼ZH](https://github.com/ZHONGHuanGit/ZhihuDaily))
+### ZhiHuDaily (By [小贼ZH](https://github.com/ZHONGHuanGit/ZhihuDaily))
 
 Zhihu is the chinese website like quora
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,23 +5,23 @@ FlashlightPlugins
 
 基于 Flashlight (https://github.com/nate-parrott/Flashlight/) 的中文插件列表
 
-##Install##
+## Install ##
 
 - 安装并启用 Flashlight (https://github.com/nate-parrott/Flashlight/releases)
 - 复制你需要启用的插件 (bundle 文件) 到 `~/Library/FlashlightPlugins`
 
 如果你熟悉命令行，可以用 `ln -s bundle_name.bundle ~/Library/FlashlightPlugins` 安装插件以便通过 git 更新。
 
-##使用##
+## 使用 ##
 
-###Timestamp###
+### Timestamp ###
 
 - `timestamp` 查看当前时间戳
 - `timestamp 1400000000` 将时间戳转化成可读的字符串形式
 
 `ts` 是 `timestamp` 的缩写，你可以用 `ts 1400000000` 以减少输入。
 
-###搜狗号码通###
+### 搜狗号码通 ###
 
 - `haomatong 10086` 从搜狗号码通查看号码相关信息
 
@@ -29,13 +29,13 @@ FlashlightPlugins
 
 ![Haomatong](images/haomatong.png)
 
-###快递 100###
+### 快递 100 ###
 
 - `kuaidi 100033892580` 从快递 100 获取快递信息
 
 ![Kuaidi](images/kuaidi.png)
 
-###有道词典 (作者：[Hyde Wang](https://github.com/callmewhy))###
+### 有道词典 (作者：[Hyde Wang](https://github.com/callmewhy)) ###
 
 - `youdao one` 英译中
 - `youdao 汪` 中译英
@@ -46,13 +46,13 @@ FlashlightPlugins
 
 ![Youdao](images/youdao.png)
 
-###Douban###
+### Douban ###
 
 - `douban 星际穿越` 搜索电影
 
 ![Douban](images/douban.png)
 
-###知乎日报 (By [小贼ZH](https://github.com/ZHONGHuanGit/ZhihuDaily))
+### 知乎日报 (By [小贼ZH](https://github.com/ZHONGHuanGit/ZhihuDaily))
 
 
 - `zhihu daily`  展示日报


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
